### PR TITLE
Makes simple-kibana compatible with opsworks

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,6 @@ maintainer_email 'jsirex@gmail.com'
 license          'Apache 2.0'
 description      'Installs Kibana ~> 4.0'
 long_description 'Installs Kibana ~> 4.0. No less, no more'
-issues_url       'https://github.com/jsirex/simple-kibana-cookbook/issues'
-source_url       'https://github.com/jsirex/simple-kibana-cookbook'
 
 version          '0.3.0'
 


### PR DESCRIPTION
By removing `issues_url` and `source_url`, we can make this cookbook
compatible with opsworks (chef 11).
