### PR TITLE
Typo fix in attribute file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 default['kibana']['download_url'] = 'https://download.elasticsearch.org/kibana/kibana/kibana-4.0.2-linux-x64.tar.gz'
 default['kibana']['checksum'] = '4cc36e5c6ca7c495667319df75feda1facb7c43a3d9686841f07a2522adec294'
 default['kibana']['version'] = '4.0.2'
-f
+
 default['kibana']['user'] = 'kibana'
 default['kibana']['group'] = 'kibana'
 default['kibana']['dir'] = '/opt'


### PR DESCRIPTION
This modest PR removes a typo that was accidentally introduced in https://github.com/jsirex/simple-kibana-cookbook/commit/9acc939c9cd546cfc8578c0180b0515814679747 and prevents the cookbook to run.
