### PR TITLE
Fixing a Chef 11 compatibility issue

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,10 +4,10 @@ maintainer_email 'jsirex@gmail.com'
 license          'Apache 2.0'
 description      'Installs Kibana ~> 4.0'
 long_description 'Installs Kibana ~> 4.0. No less, no more'
-issues_url       'https://github.com/jsirex/simple-kibana-cookbook/issues'
-source_url       'https://github.com/jsirex/simple-kibana-cookbook'
+issues_url       'https://github.com/jsirex/simple-kibana-cookbook/issues' if respond_to?(:issues_url)
+source_url       'https://github.com/jsirex/simple-kibana-cookbook' if respond_to?(:source_url)
 
-version          '0.4.1'
+version          '0.4.2'
 
 depends 'ark'
 depends 'runit'


### PR DESCRIPTION
The issues_url and source_url attributes are not compatible with Chef 11. This is a simple fix for it.
