### PR TITLE
Install kibana 4.5.0 by default (requires elasticsearch 2.3.0, updated config).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Description
 
-This cookbook installs kibana 4.x only.
+This cookbook installs kibana 4.5.x only.
 It doesn't install or depends on java, apache, nginx, etc...
+
+Since kibana 4.5.x requires elasticsearch >= 2.3.0 you will have to install that version or more recent.
 
 # Usage
 
-Override both `node['kibana']['download_url']`, `node['kibana']['checsum']`, `node['kibana']['version']`.
+Override both `node['kibana']['download_url']`, `node['kibana']['checksum']`, `node['kibana']['version']`.
 
 # Custom init service
 
@@ -35,22 +37,28 @@ include_recipe 'mywrapper-kibana::service_upstart' # I want to use upstart
 
 # Attributes
 
-* `node['kibana']['config']['port']` -  Defaults to `5601`.
-* `node['kibana']['config']['host']` -  Defaults to `0.0.0.0`.
-* `node['kibana']['config']['elasticsearch_url']` -  Defaults to `http://localhost:9200`.
-* `node['kibana']['config']['kibana_index']` -  Defaults to `.kibana`.
-* `node['kibana']['config']['default_app_id']` -  Defaults to `discover`.
-* `node['kibana']['config']['request_timeout']` -  Defaults to `300000`.
-* `node['kibana']['config']['shard_timeout']` -  Defaults to `0`.
-* `node['kibana']['config']['verify_ssl']` -  Defaults to `true`.
-* `node['kibana']['config']['bundled_plugin_ids']` -  Defaults to `[ ... ]`.
-* `node['kibana']['download_url']` -  Defaults to `https://download.elasticsearch.org/kibana/kibana/kibana-4.1.3-linux-x64.tar.gz`.
-* `node['kibana']['checksum']` -  Defaults to `f2cb5389ad0acfbc4006f739d75d5ede541483d1fa6be728bbf547a9d7ddeb4a`.
-* `node['kibana']['version']` -  Defaults to `4.1.3`.
-* `node['kibana']['user']` -  Defaults to `kibana`.
-* `node['kibana']['group']` -  Defaults to `kibana`.
-* `node['kibana']['dir']` -  Defaults to `/opt`.
-* `node['kibana']['path']['logs']` -  Defaults to `/var/log/kibana`.
+* `default['kibana']['download_url']` - Defaults to `'https://download.elastic.co/kibana/kibana/kibana-4.5.0-linux-x64.tar.gz'`.
+* `default['kibana']['checksum']` - Defaults to `'fa3f675febb34c0f676f8a64537967959eb95d2f5a81bc6da17aa5c98b9c76ef'`.
+* `default['kibana']['version']` - Defaults to `'4.5.0'`.
+* `default['kibana']['user']` - Defaults to `'kibana'`.
+* `default['kibana']['group']` - Defaults to `'kibana'`.
+* `default['kibana']['dir']` - Defaults to `'/opt'`.
+* `default['kibana']['path']['logs']` - Defaults to `'/var/log/kibana'`.
+
+The following attributes map to entries in kibana configuration file:
+
+* `default['kibana']['config']['port']` - Defaults to `5601`.
+* `default['kibana']['config']['host']` - Defaults to `'0.0.0.0'`.
+* `default['kibana']['config']['elasticsearch.url']` - Defaults to `'http://localhost:9200'`.
+* `default['kibana']['config']['elasticsearch.preserveHost']` - Defaults to `true`.
+* `default['kibana']['config']['kibana.index']` - Defaults to `'.kibana'`.
+* `default['kibana']['config']['kibana.defaultAppId']` - Defaults to `'discover'`.
+* `default['kibana']['config']['elasticsearch.ssl.verify']` - Defaults to `true`.
+* `default['kibana']['config']['elasticsearch.requestTimeout']` - Defaults to `300000`.
+* `default['kibana']['config']['elasticsearch.shardTimeout']` - Defaults to `0`.
+* `default['kibana']['config']['elasticsearch.startupTimeout']` - Defaults to `5000`.
+
+Other configuration file attributes may be used but they are not explicitly set in this cookbook.
 
 # Recipes
 

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -4,38 +4,76 @@ default['kibana']['config']['port'] = 5601
 # The host to bind the server to.
 default['kibana']['config']['host'] = '0.0.0.0'
 
+# If you are running kibana behind a proxy, and want to mount it at a path,
+# specify that path here. The basePath can't end in a slash.
+# default['kibana']['config']['server.basePath'] = ""
+
+# The maximum payload size in bytes on incoming server requests.
+# default['kibana']['config']['server.maxPayloadBytes'] = 1048576
+
 # The Elasticsearch instance to use for all your queries.
-default['kibana']['config']['elasticsearch_url'] = 'http://localhost:9200'
+default['kibana']['config']['elasticsearch.url'] = 'http://localhost:9200'
+
+# preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
+# then the host you use to connect to *this* Kibana instance will be sent.
+default['kibana']['config']['elasticsearch.preserveHost'] = true
 
 # Kibana uses an index in Elasticsearch to store saved searches, visualizations
 # and dashboards. It will create a new index if it doesn't already exist.
-default['kibana']['config']['kibana_index'] = '.kibana'
+default['kibana']['config']['kibana.index'] = '.kibana'
 
 # The default application to load.
-default['kibana']['config']['default_app_id'] = 'discover'
+default['kibana']['config']['kibana.defaultAppId'] = 'discover'
 
-# Time in milliseconds to wait for responses from the back end or elasticsearch.
-# This must be > 0
-default['kibana']['config']['request_timeout'] = 300000
+# If your Elasticsearch is protected with basic auth, these are the user credentials
+# used by the Kibana server to perform maintenance on the kibana_index at startup. Your Kibana
+# users will still need to authenticate with Elasticsearch (which is proxied through
+# the Kibana server)
+# default['kibana']['config']['elasticsearch.username'] = "user"
+# default['kibana']['config']['elasticsearch.password'] = "pass"
 
-# Time in milliseconds for Elasticsearch to wait for responses from shards.
-# Note this should always be lower than "request_timeout".
-# Set to 0 to disable (not recommended).
-default['kibana']['config']['shard_timeout'] = 0
+# SSL for outgoing requests from the Kibana Server to the browser (PEM formatted)
+# default['kibana']['config']['server.ssl.cert'] = "/path/to/your/server.crt"
+# default['kibana']['config']['server.ssl.key'] = "/path/to/your/server.key"
+
+# Optional setting to validate that your Elasticsearch backend uses the same key files (PEM formatted)
+# default['kibana']['config']['elasticsearch.ssl.cert'] = "/path/to/your/client.crt"
+# default['kibana']['config']['elasticsearch.ssl.key'] = "/path/to/your/client.key"
+
+# If you need to provide a CA certificate for your Elasticsearch instance, put
+# the path of the pem file here.
+# default['kibana']['config']['elasticsearch.ssl.ca'] = "/path/to/your/CA.pem"
 
 # Set to false to have a complete disregard for the validity of the SSL
 # certificate.
-default['kibana']['config']['verify_ssl'] = true
+default['kibana']['config']['elasticsearch.ssl.verify'] = true
 
-# Plugins that are included in the build, and no longer found in the plugins/ folder
-default['kibana']['config']['bundled_plugin_ids'] = [
-  'plugins/dashboard/index',
-  'plugins/discover/index',
-  'plugins/doc/index',
-  'plugins/kibana/index',
-  'plugins/metric_vis/index',
-  'plugins/settings/index',
-  'plugins/table_vis/index',
-  'plugins/vis_types/index',
-  'plugins/visualize/index'
-]
+# Time in milliseconds to wait for elasticsearch to respond to pings, defaults to
+# request_timeout setting
+# default['kibana']['config']['elasticsearch.pingTimeout'] = "1500"
+
+# Time in milliseconds to wait for responses from the back end or elasticsearch.
+# This must be > 0
+default['kibana']['config']['elasticsearch.requestTimeout'] = 300000
+
+# Time in milliseconds for Elasticsearch to wait for responses from shards.
+# Set to 0 to disable.
+default['kibana']['config']['elasticsearch.shardTimeout'] = 0
+
+# Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying
+default['kibana']['config']['elasticsearch.startupTimeout'] = 5000
+
+# Set the path to where you would like the process id file to be created.
+# default['kibana']['config']['pid.file'] = "/var/run/kibana.pid"
+
+# If you would like to send the log output to a file you can set the path below.
+# default['kibana']['config']['logging.dest'] = "stdout"
+
+# Set this to true to suppress all logging output.
+# default['kibana']['config']['logging.silent'] = false
+
+# Set this to true to suppress all logging output except for error messages.
+# default['kibana']['config']['logging.quiet'] = false
+
+# Set this to true to log all events, including system usage information and all requests.
+# default['kibana']['config']['logging.verbose'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
-default['kibana']['download_url'] = 'https://download.elasticsearch.org/kibana/kibana/kibana-4.1.3-linux-x64.tar.gz'
-default['kibana']['checksum'] = 'f2cb5389ad0acfbc4006f739d75d5ede541483d1fa6be728bbf547a9d7ddeb4a'
-default['kibana']['version'] = '4.1.3'
+default['kibana']['download_url'] = 'https://download.elastic.co/kibana/kibana/kibana-4.5.0-linux-x64.tar.gz'
+default['kibana']['checksum'] = 'fa3f675febb34c0f676f8a64537967959eb95d2f5a81bc6da17aa5c98b9c76ef'
+default['kibana']['version'] = '4.5.0'
 
 default['kibana']['user'] = 'kibana'
 default['kibana']['group'] = 'kibana'

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -3,7 +3,7 @@ It doesn't install or depends on java, apache, nginx, etc...
 
 # Usage
 
-Override both `node['kibana']['download_url']`, `node['kibana']['checsum']`, `node['kibana']['version']`.
+Override both `node['kibana']['download_url']`, `node['kibana']['checksum']`, `node['kibana']['version']`.
 
 # Custom init service
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,8 +2,8 @@ name             'simple-kibana'
 maintainer       'Yauhen Artsiukhou'
 maintainer_email 'jsirex@gmail.com'
 license          'Apache 2.0'
-description      'Installs Kibana ~> 4.0'
-long_description 'Installs Kibana ~> 4.0. No less, no more'
+description      'Installs Kibana ~> 4.5'
+long_description 'Installs Kibana ~> 4.5. No less, no more'
 issues_url       'https://github.com/jsirex/simple-kibana-cookbook/issues' if respond_to?(:issues_url)
 source_url       'https://github.com/jsirex/simple-kibana-cookbook' if respond_to?(:source_url)
 

--- a/templates/default/sv-kibana-run.erb
+++ b/templates/default/sv-kibana-run.erb
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-cd /<%= @options['home'] %>
+cd <%= @options['home'] %>
 exec 2>&1
 
-exec chpst -u <%= @options['user'] %> <%= @options['home'] %>/bin/kibana
+exec chpst -u <%= @options['user'] %> <%= @options['home'] %>/bin/kibana -c <%= ::File.join(@options['home'], 'config', 'kibana.yml') %>
 


### PR DESCRIPTION
This PR updates this cookbook to install the recently released kibana 4.5.0, which goes with the recently released elasticsearch 2.3.0.

Please note that the format of the kibana configuration file (see attributes/config.rb) has changed; you should release a new major version of this cookbook if you decide to merge this PR.
